### PR TITLE
Add new test cases on numbers written in scientific notation.

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -44,6 +44,16 @@ describe('convert', () => {
     expect(convert(([] as unknown) as number)).toBe(false);
   });
 
+  it('should returns consistent result when use scientific notation', () => {
+    expect(convert('1e+3')).toEqual(convert(-1e+3));
+    expect(convert('1e+3')).toEqual(convert(1e+3));
+    expect(convert('1.2e+3')).toEqual(convert(1.2e+3));
+    expect(convert('-1.2e+3')).toEqual(convert(-1.2e+3));
+    expect(convert('1e-2')).toEqual(convert(1e-2));
+    expect(convert('1.2e-1')).toEqual(convert(1.2e-1));
+    expect(convert('-1.2e-1')).toEqual(convert(-1.2e-1));
+  });
+
   it('should be a function', () => {
     expect(convert).toEqual(expect.any(Function));
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -44,14 +44,14 @@ describe('convert', () => {
     expect(convert(([] as unknown) as number)).toBe(false);
   });
 
-  it('should returns consistent result when use scientific notation', () => {
-    expect(convert('1e+3')).toEqual(convert(-1e+3));
-    expect(convert('1e+3')).toEqual(convert(1e+3));
-    expect(convert('1.2e+3')).toEqual(convert(1.2e+3));
-    expect(convert('-1.2e+3')).toEqual(convert(-1.2e+3));
-    expect(convert('1e-2')).toEqual(convert(1e-2));
-    expect(convert('1.2e-1')).toEqual(convert(1.2e-1));
-    expect(convert('-1.2e-1')).toEqual(convert(-1.2e-1));
+  it('should not returns undefined string included within results when use scientific notation', () => {
+    expect(convert('1e+3')).not.toContain('undefined');
+    expect(convert('1e+3')).not.toContain('undefined');
+    expect(convert('1.2e+3')).not.toContain('undefined');
+    expect(convert('-1.2e+3')).not.toContain('undefined');
+    expect(convert('1e-2')).not.toContain('undefined');
+    expect(convert('1.2e-1')).not.toContain('undefined');
+    expect(convert('-1.2e-1')).not.toContain('undefined');
   });
 
   it('should be a function', () => {


### PR DESCRIPTION
## Brief description

currently, when convert string of number written in scientific notation -- results are mismatched with their number counterpart.

unsure whether if this project will supports scientific notations or not, this pull request assuming in either case, output should not included with `undefined`.

thus, these test case will failed against current commit on main branch.

Or, if this project decided on how it should handle scientific notation string. I'd be happy to implement them too. 🎉 