### PR TITLE
Fix leading/trailing spaces/zeros problem

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,17 +60,19 @@ export function convert(input: number | string): string | boolean {
       : Math.floor(((input + Number.EPSILON * (baht || 1)) * 100) % 100);
     bahtStr = '' + baht;
   } else if (typeof input === 'string') {
-    let negativeLeadingZeroPattern = /^-0+/;
+    let formattedInput = input.trim();
 
-    if (input.startsWith('-')) {
-      if (input === '-0') {
-        input = '0';
-      } else {
-        input = input.replace(negativeLeadingZeroPattern, '-');
+    if (formattedInput.startsWith('-')) {
+      formattedInput = formattedInput.replace(/^-0+/, '-');
+      if (formattedInput === '-') {
+        // catch "-0" (also catch "-" — consideration needed)
+        formattedInput = '0';
       }
+    } else {
+      formattedInput = formattedInput.replace(/^0+/, '');
     }
 
-    let inputNum = Number(input);
+    let inputNum = Number(formattedInput);
 
     if (isNaN(inputNum)) {
       return false;
@@ -79,10 +81,10 @@ export function convert(input: number | string): string | boolean {
     if (inputNum < 0) {
       isNegative = true;
       inputNum = -inputNum;
-      input = input.slice(1);
+      formattedInput = formattedInput.slice(1);
     }
 
-    const inputStr = input;
+    const inputStr = formattedInput;
 
     let periodIdx;
     if (

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -294,122 +294,150 @@ describe('convert', () => {
     );
   });
 
-  // This explicit test cases is for explicit testing (means that you'll see the number that errors)
-  // After that, you should wrap this in a single `it` block.
   it('should convert spaces as 0', () => {
-    // Normal Space
     expect(convert(('' as unknown) as number)).toBe('ศูนย์บาทถ้วน');
     expect(convert((' ' as unknown) as number)).toBe('ศูนย์บาทถ้วน');
     expect(convert(('  ' as unknown) as number)).toBe('ศูนย์บาทถ้วน');
   });
 
-  // TODO: wrap in `it("should convert number surrounding with spaces or zeros correctly", () => {/* */})`
-  const generateSpaceTest = (
-    input: string,
-    output: string,
-    negativeOutput = ''
-  ) => {
-    const neg_output = negativeOutput || 'ลบ' + output;
+  it('should convert number surrounding with spaces or zeros correctly', () => {
+    const generateSpaceTest = (
+      input: string,
+      output: string,
+      negativeOutput = ''
+    ) => {
+      const neg_output = negativeOutput || 'ลบ' + output;
 
-    const int_tests = [
-      [` ${input}`, output],
-      [`${input} `, output],
-      [` ${input} `, output],
-      [` 0${input}`, output],
-      [`0${input} `, output],
-      [` 0${input} `, output],
-      [` -${input}`, neg_output],
-      [`-${input} `, neg_output],
-      [` -${input} `, neg_output],
-      [` -0${input}`, neg_output],
-      [`-0${input} `, neg_output],
-      [` -0${input} `, neg_output],
-    ];
+      const int_tests = [
+        [` ${input}`, output],
+        [`${input} `, output],
+        [` ${input} `, output],
+        [` 0${input}`, output],
+        [`0${input} `, output],
+        [` 0${input} `, output],
+        [` 00${input}`, output],
+        [`00${input} `, output],
+        [` 00${input} `, output],
+        [` -${input}`, neg_output],
+        [`-${input} `, neg_output],
+        [` -${input} `, neg_output],
+        [` -0${input}`, neg_output],
+        [`-0${input} `, neg_output],
+        [` -0${input} `, neg_output],
+        [` -00${input}`, neg_output],
+        [`-00${input} `, neg_output],
+        [` -00${input} `, neg_output],
+      ];
 
-    const float_tests = [
-      [` ${input}0`, output],
-      [`${input}0 `, output],
-      [` ${input}0 `, output],
-      [` 0${input}0`, output],
-      [`0${input}0 `, output],
-      [` 0${input}0 `, output],
-      [` -${input}0`, neg_output],
-      [`-${input}0 `, neg_output],
-      [` -${input}0 `, neg_output],
-      [` -0${input}0`, neg_output],
-      [`-0${input}0 `, neg_output],
-      [` -0${input}0 `, neg_output],
-    ];
+      const float_tests = [
+        [` ${input}0`, output],
+        [`${input}0 `, output],
+        [` ${input}0 `, output],
+        [` ${input}00`, output],
+        [`${input}00 `, output],
+        [` ${input}00 `, output],
+        [` 0${input}0`, output],
+        [`0${input}0 `, output],
+        [` 0${input}0 `, output],
+        [` 0${input}00`, output],
+        [`0${input}00 `, output],
+        [` 0${input}00 `, output],
+        [` 00${input}0`, output],
+        [`00${input}0 `, output],
+        [` 00${input}0 `, output],
+        [` 00${input}00`, output],
+        [`00${input}00 `, output],
+        [` 00${input}00 `, output],
+        [` -${input}0`, neg_output],
+        [`-${input}0 `, neg_output],
+        [` -${input}0 `, neg_output],
+        [` -${input}00`, neg_output],
+        [`-${input}00 `, neg_output],
+        [` -${input}00 `, neg_output],
+        [` -0${input}0`, neg_output],
+        [`-0${input}0 `, neg_output],
+        [` -0${input}0 `, neg_output],
+        [` -0${input}00`, neg_output],
+        [`-0${input}00 `, neg_output],
+        [` -0${input}00 `, neg_output],
+        [` -00${input}0`, neg_output],
+        [`-00${input}0 `, neg_output],
+        [` -00${input}0 `, neg_output],
+        [` -00${input}00`, neg_output],
+        [`-00${input}00 `, neg_output],
+        [` -00${input}00 `, neg_output],
+      ];
 
-    const tests = input.includes('.')
-      ? int_tests.concat(float_tests)
-      : int_tests;
+      const tests = input.includes('.')
+        ? int_tests.concat(float_tests)
+        : int_tests;
 
-    it.each(tests)('"%s" => %s', (input, expected) => {
-      expect(convert((input as unknown) as number)).toBe(expected);
-    });
-  };
+      tests.forEach(([input, expected]) => {
+        expect(convert((input as unknown) as number)).toBe(expected);
+      });
+    };
 
-  // Normal Test
-  generateSpaceTest('0', 'ศูนย์บาทถ้วน', 'ศูนย์บาทถ้วน'); // -0 is same as 0
-  generateSpaceTest('0.0', 'ศูนย์บาทถ้วน', 'ศูนย์บาทถ้วน'); // -0.0 is same as 0.0
-  generateSpaceTest('0.5', 'ห้าสิบสตางค์');
-  generateSpaceTest('0.00', 'ศูนย์บาทถ้วน', 'ศูนย์บาทถ้วน'); // -0.00 is same as 0.00
-  generateSpaceTest('0.50', 'ห้าสิบสตางค์');
-  generateSpaceTest('0.55', 'ห้าสิบห้าสตางค์');
+    // Normal Test
+    generateSpaceTest('0', 'ศูนย์บาทถ้วน', 'ศูนย์บาทถ้วน'); // -0 is same as 0
+    generateSpaceTest('0.0', 'ศูนย์บาทถ้วน', 'ศูนย์บาทถ้วน'); // -0.0 is same as 0.0
+    generateSpaceTest('0.5', 'ห้าสิบสตางค์');
+    generateSpaceTest('0.00', 'ศูนย์บาทถ้วน', 'ศูนย์บาทถ้วน'); // -0.00 is same as 0.00
+    generateSpaceTest('0.50', 'ห้าสิบสตางค์');
+    generateSpaceTest('0.55', 'ห้าสิบห้าสตางค์');
 
-  generateSpaceTest('1', 'หนึ่งบาทถ้วน');
-  generateSpaceTest('1.0', 'หนึ่งบาทถ้วน');
-  generateSpaceTest('9.5', 'เก้าบาทห้าสิบสตางค์');
-  generateSpaceTest('9.00', 'เก้าบาทถ้วน');
-  generateSpaceTest('9.50', 'เก้าบาทห้าสิบสตางค์');
-  generateSpaceTest('9.55', 'เก้าบาทห้าสิบห้าสตางค์');
+    generateSpaceTest('1', 'หนึ่งบาทถ้วน');
+    generateSpaceTest('1.0', 'หนึ่งบาทถ้วน');
+    generateSpaceTest('9.5', 'เก้าบาทห้าสิบสตางค์');
+    generateSpaceTest('9.00', 'เก้าบาทถ้วน');
+    generateSpaceTest('9.50', 'เก้าบาทห้าสิบสตางค์');
+    generateSpaceTest('9.55', 'เก้าบาทห้าสิบห้าสตางค์');
 
-  generateSpaceTest('11', 'สิบเอ็ดบาทถ้วน');
-  generateSpaceTest('11.0', 'สิบเอ็ดบาทถ้วน');
-  generateSpaceTest('11.5', 'สิบเอ็ดบาทห้าสิบสตางค์');
-  generateSpaceTest('11.00', 'สิบเอ็ดบาทถ้วน');
-  generateSpaceTest('11.50', 'สิบเอ็ดบาทห้าสิบสตางค์');
-  generateSpaceTest('12.34', 'สิบสองบาทสามสิบสี่สตางค์');
+    generateSpaceTest('11', 'สิบเอ็ดบาทถ้วน');
+    generateSpaceTest('11.0', 'สิบเอ็ดบาทถ้วน');
+    generateSpaceTest('11.5', 'สิบเอ็ดบาทห้าสิบสตางค์');
+    generateSpaceTest('11.00', 'สิบเอ็ดบาทถ้วน');
+    generateSpaceTest('11.50', 'สิบเอ็ดบาทห้าสิบสตางค์');
+    generateSpaceTest('12.34', 'สิบสองบาทสามสิบสี่สตางค์');
 
-  // From other tests
-  generateSpaceTest(
-    '123456789.999',
-    'หนึ่งร้อยยี่สิบสามล้านสี่แสนห้าหมื่นหกพันเจ็ดร้อยแปดสิบเก้าบาทเก้าสิบเก้าสตางค์'
-  );
-  generateSpaceTest(
-    '4123001998830750501',
-    'สี่ล้านหนึ่งแสนสองหมื่นสามพันเอ็ดล้านเก้าแสนเก้าหมื่นแปดพันแปดร้อยสามสิบล้านเจ็ดแสนห้าหมื่นห้าร้อยเอ็ดบาทถ้วน'
-  );
-  generateSpaceTest(
-    '4123001998830750501.21',
-    'สี่ล้านหนึ่งแสนสองหมื่นสามพันเอ็ดล้านเก้าแสนเก้าหมื่นแปดพันแปดร้อยสามสิบล้านเจ็ดแสนห้าหมื่นห้าร้อยเอ็ดบาทยี่สิบเอ็ดสตางค์'
-  );
-  generateSpaceTest(
-    '1654321.21',
-    'หนึ่งล้านหกแสนห้าหมื่นสี่พันสามร้อยยี่สิบเอ็ดบาทยี่สิบเอ็ดสตางค์'
-  );
+    // From other tests
+    generateSpaceTest(
+      '123456789.999',
+      'หนึ่งร้อยยี่สิบสามล้านสี่แสนห้าหมื่นหกพันเจ็ดร้อยแปดสิบเก้าบาทเก้าสิบเก้าสตางค์'
+    );
+    generateSpaceTest(
+      '4123001998830750501',
+      'สี่ล้านหนึ่งแสนสองหมื่นสามพันเอ็ดล้านเก้าแสนเก้าหมื่นแปดพันแปดร้อยสามสิบล้านเจ็ดแสนห้าหมื่นห้าร้อยเอ็ดบาทถ้วน'
+    );
+    generateSpaceTest(
+      '4123001998830750501.21',
+      'สี่ล้านหนึ่งแสนสองหมื่นสามพันเอ็ดล้านเก้าแสนเก้าหมื่นแปดพันแปดร้อยสามสิบล้านเจ็ดแสนห้าหมื่นห้าร้อยเอ็ดบาทยี่สิบเอ็ดสตางค์'
+    );
+    generateSpaceTest(
+      '1654321.21',
+      'หนึ่งล้านหกแสนห้าหมื่นสี่พันสามร้อยยี่สิบเอ็ดบาทยี่สิบเอ็ดสตางค์'
+    );
 
-  // IEEE Test
-  generateSpaceTest('0.29', 'ยี่สิบเก้าสตางค์');
-  generateSpaceTest('553.57', 'ห้าร้อยห้าสิบสามบาทห้าสิบเจ็ดสตางค์');
-  generateSpaceTest('790.58', 'เจ็ดร้อยเก้าสิบบาทห้าสิบแปดสตางค์');
-  generateSpaceTest(
-    '283798.29',
-    'สองแสนแปดหมื่นสามพันเจ็ดร้อยเก้าสิบแปดบาทยี่สิบเก้าสตางค์'
-  );
-  generateSpaceTest(
-    '486293.57',
-    'สี่แสนแปดหมื่นหกพันสองร้อยเก้าสิบสามบาทห้าสิบเจ็ดสตางค์'
-  );
-  generateSpaceTest(
-    '874552164.58',
-    'แปดร้อยเจ็ดสิบสี่ล้านห้าแสนห้าหมื่นสองพันหนึ่งร้อยหกสิบสี่บาทห้าสิบแปดสตางค์'
-  );
-  generateSpaceTest(
-    '5143289600432.29',
-    'ห้าล้านหนึ่งแสนสี่หมื่นสามพันสองร้อยแปดสิบเก้าล้านหกแสนสี่ร้อยสามสิบสองบาทยี่สิบเก้าสตางค์'
-  );
+    // IEEE Test
+    generateSpaceTest('0.29', 'ยี่สิบเก้าสตางค์');
+    generateSpaceTest('553.57', 'ห้าร้อยห้าสิบสามบาทห้าสิบเจ็ดสตางค์');
+    generateSpaceTest('790.58', 'เจ็ดร้อยเก้าสิบบาทห้าสิบแปดสตางค์');
+    generateSpaceTest(
+      '283798.29',
+      'สองแสนแปดหมื่นสามพันเจ็ดร้อยเก้าสิบแปดบาทยี่สิบเก้าสตางค์'
+    );
+    generateSpaceTest(
+      '486293.57',
+      'สี่แสนแปดหมื่นหกพันสองร้อยเก้าสิบสามบาทห้าสิบเจ็ดสตางค์'
+    );
+    generateSpaceTest(
+      '874552164.58',
+      'แปดร้อยเจ็ดสิบสี่ล้านห้าแสนห้าหมื่นสองพันหนึ่งร้อยหกสิบสี่บาทห้าสิบแปดสตางค์'
+    );
+    generateSpaceTest(
+      '5143289600432.29',
+      'ห้าล้านหนึ่งแสนสี่หมื่นสามพันสองร้อยแปดสิบเก้าล้านหกแสนสี่ร้อยสามสิบสองบาทยี่สิบเก้าสตางค์'
+    );
+  });
 
   // it('equals to value from other library (STRESS TEST)', () => {
   //   for (let i = 1; i < 20000000; i += 1) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -294,6 +294,123 @@ describe('convert', () => {
     );
   });
 
+  // This explicit test cases is for explicit testing (means that you'll see the number that errors)
+  // After that, you should wrap this in a single `it` block.
+  it('should convert spaces as 0', () => {
+    // Normal Space
+    expect(convert(('' as unknown) as number)).toBe('ศูนย์บาทถ้วน');
+    expect(convert((' ' as unknown) as number)).toBe('ศูนย์บาทถ้วน');
+    expect(convert(('  ' as unknown) as number)).toBe('ศูนย์บาทถ้วน');
+  });
+
+  // TODO: wrap in `it("should convert number surrounding with spaces or zeros correctly", () => {/* */})`
+  const generateSpaceTest = (
+    input: string,
+    output: string,
+    negativeOutput = ''
+  ) => {
+    const neg_output = negativeOutput || 'ลบ' + output;
+
+    const int_tests = [
+      [` ${input}`, output],
+      [`${input} `, output],
+      [` ${input} `, output],
+      [` 0${input}`, output],
+      [`0${input} `, output],
+      [` 0${input} `, output],
+      [` -${input}`, neg_output],
+      [`-${input} `, neg_output],
+      [` -${input} `, neg_output],
+      [` -0${input}`, neg_output],
+      [`-0${input} `, neg_output],
+      [` -0${input} `, neg_output],
+    ];
+
+    const float_tests = [
+      [` ${input}0`, output],
+      [`${input}0 `, output],
+      [` ${input}0 `, output],
+      [` 0${input}0`, output],
+      [`0${input}0 `, output],
+      [` 0${input}0 `, output],
+      [` -${input}0`, neg_output],
+      [`-${input}0 `, neg_output],
+      [` -${input}0 `, neg_output],
+      [` -0${input}0`, neg_output],
+      [`-0${input}0 `, neg_output],
+      [` -0${input}0 `, neg_output],
+    ];
+
+    const tests = input.includes('.')
+      ? int_tests.concat(float_tests)
+      : int_tests;
+
+    it.each(tests)('"%s" => %s', (input, expected) => {
+      expect(convert((input as unknown) as number)).toBe(expected);
+    });
+  };
+
+  // Normal Test
+  generateSpaceTest('0', 'ศูนย์บาทถ้วน', 'ศูนย์บาทถ้วน'); // -0 is same as 0
+  generateSpaceTest('0.0', 'ศูนย์บาทถ้วน', 'ศูนย์บาทถ้วน'); // -0.0 is same as 0.0
+  generateSpaceTest('0.5', 'ห้าสิบสตางค์');
+  generateSpaceTest('0.00', 'ศูนย์บาทถ้วน', 'ศูนย์บาทถ้วน'); // -0.00 is same as 0.00
+  generateSpaceTest('0.50', 'ห้าสิบสตางค์');
+  generateSpaceTest('0.55', 'ห้าสิบห้าสตางค์');
+
+  generateSpaceTest('1', 'หนึ่งบาทถ้วน');
+  generateSpaceTest('1.0', 'หนึ่งบาทถ้วน');
+  generateSpaceTest('9.5', 'เก้าบาทห้าสิบสตางค์');
+  generateSpaceTest('9.00', 'เก้าบาทถ้วน');
+  generateSpaceTest('9.50', 'เก้าบาทห้าสิบสตางค์');
+  generateSpaceTest('9.55', 'เก้าบาทห้าสิบห้าสตางค์');
+
+  generateSpaceTest('11', 'สิบเอ็ดบาทถ้วน');
+  generateSpaceTest('11.0', 'สิบเอ็ดบาทถ้วน');
+  generateSpaceTest('11.5', 'สิบเอ็ดบาทห้าสิบสตางค์');
+  generateSpaceTest('11.00', 'สิบเอ็ดบาทถ้วน');
+  generateSpaceTest('11.50', 'สิบเอ็ดบาทห้าสิบสตางค์');
+  generateSpaceTest('12.34', 'สิบสองบาทสามสิบสี่สตางค์');
+
+  // From other tests
+  generateSpaceTest(
+    '123456789.999',
+    'หนึ่งร้อยยี่สิบสามล้านสี่แสนห้าหมื่นหกพันเจ็ดร้อยแปดสิบเก้าบาทเก้าสิบเก้าสตางค์'
+  );
+  generateSpaceTest(
+    '4123001998830750501',
+    'สี่ล้านหนึ่งแสนสองหมื่นสามพันเอ็ดล้านเก้าแสนเก้าหมื่นแปดพันแปดร้อยสามสิบล้านเจ็ดแสนห้าหมื่นห้าร้อยเอ็ดบาทถ้วน'
+  );
+  generateSpaceTest(
+    '4123001998830750501.21',
+    'สี่ล้านหนึ่งแสนสองหมื่นสามพันเอ็ดล้านเก้าแสนเก้าหมื่นแปดพันแปดร้อยสามสิบล้านเจ็ดแสนห้าหมื่นห้าร้อยเอ็ดบาทยี่สิบเอ็ดสตางค์'
+  );
+  generateSpaceTest(
+    '1654321.21',
+    'หนึ่งล้านหกแสนห้าหมื่นสี่พันสามร้อยยี่สิบเอ็ดบาทยี่สิบเอ็ดสตางค์'
+  );
+
+  // IEEE Test
+  generateSpaceTest('0.29', 'ยี่สิบเก้าสตางค์');
+  generateSpaceTest('553.57', 'ห้าร้อยห้าสิบสามบาทห้าสิบเจ็ดสตางค์');
+  generateSpaceTest('790.58', 'เจ็ดร้อยเก้าสิบบาทห้าสิบแปดสตางค์');
+  generateSpaceTest(
+    '283798.29',
+    'สองแสนแปดหมื่นสามพันเจ็ดร้อยเก้าสิบแปดบาทยี่สิบเก้าสตางค์'
+  );
+  generateSpaceTest(
+    '486293.57',
+    'สี่แสนแปดหมื่นหกพันสองร้อยเก้าสิบสามบาทห้าสิบเจ็ดสตางค์'
+  );
+  generateSpaceTest(
+    '874552164.58',
+    'แปดร้อยเจ็ดสิบสี่ล้านห้าแสนห้าหมื่นสองพันหนึ่งร้อยหกสิบสี่บาทห้าสิบแปดสตางค์'
+  );
+  generateSpaceTest(
+    '5143289600432.29',
+    'ห้าล้านหนึ่งแสนสี่หมื่นสามพันสองร้อยแปดสิบเก้าล้านหกแสนสี่ร้อยสามสิบสองบาทยี่สิบเก้าสตางค์'
+  );
+
   // it('equals to value from other library (STRESS TEST)', () => {
   //   for (let i = 1; i < 20000000; i += 1) {
   //     expect(convert(i)).toEqual(bahtLatest(i));


### PR DESCRIPTION
## Summary
- Adding more test to cover more input, this includes:
  - Add space(s) around number string.
  - Add leading and trailing zero(s).
- Fix #14, now `convert("01")` is actually `"หนึ่งบาทถ้วน"`.
- Fix the wrong output problem when string has space around it. These are some of the incorrect output in version 0.7.0:
  - `convert(" 1")` => `"สิบเอ็ดบาทถ้วน"`  (instead of `"หนึ่งบาทถ้วน"`)
  - `convert("1.5 ")` => `"หนึ่งบาทห้าสตางค์"` (instead of `"หนึ่งบาทห้าสิบสตางค์"`).
  This problem has been fixed by trimming the string before process it.

## Consideration Needed
The algorithm for removing leading zeros introduce one side effect: `convert("-")` will produce `"ศูนย์บาทถ้วน"`. This happens because after replacing repeating zeros in negative number, it will check if the string is `"-"` or not; if it is, it will replace it as `"0"` (because `"-0"` = `"0"`) and hence make `"-"` valid. I want your consideration on this whether this should be a valid behavior or not. Thanks in advance.